### PR TITLE
added scroll functionality to icon-help-div

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -41,8 +41,9 @@ h3 {
   top: 20%;
   z-index: 3;
   width: 300px;
-  height: 830px;
+  height: 100%;
   opacity: 0.9;
+  overflow: scroll;
 }
 
 #show_help_btn {


### PR DESCRIPTION
icon help menu will now be scrollable, instead of extending the webpage.

Changes:
 - made icon-help-div a % height, not a pixel height
 - added the "overflow: scroll;" property to the icon-help-div ID